### PR TITLE
Add subtle animations and scroll reveal

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const reveals = document.querySelectorAll('.reveal');
+  if (reduceMotion) {
+    reveals.forEach(el => el.classList.add('visible'));
+    return;
+  }
+
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  reveals.forEach(el => observer.observe(el));
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,66 @@
+/* Additional animation styles */
+@media (prefers-reduced-motion: no-preference) {
+  /* Smooth nav link hover */
+  nav a {
+    transition: filter 0.3s ease, color 0.3s ease;
+  }
+
+  /* Interactive buttons and cards */
+  .cta,
+  .icon-btn,
+  .wa-btn,
+  .workbox {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .cta:hover {
+    transform: scale(1.03);
+    box-shadow: 0 6px 18px rgba(0,0,0,0.2);
+  }
+
+  .icon-btn:hover,
+  .wa-btn:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.25);
+  }
+
+  .workbox:hover {
+    transform: scale(1.02);
+    box-shadow: 0 12px 28px rgba(13,72,160,0.15);
+  }
+
+  /* Hero intro animation */
+  .fade-slide {
+    opacity: 0;
+    transform: translateY(20px);
+    animation: fadeSlide 0.8s ease-out forwards;
+  }
+
+  @keyframes fadeSlide {
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /* Reveal on scroll */
+  .reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  }
+
+  .reveal.visible {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-slide,
+  .reveal {
+    opacity: 1 !important;
+    transform: none !important;
+    animation: none !important;
+  }
+}

--- a/datenschutzerklaerung.html
+++ b/datenschutzerklaerung.html
@@ -14,11 +14,12 @@
     h1{margin-top:0} h2{margin-top:26px}
     ul{margin:0 0 1rem 1.2rem}
   </style>
+  <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
 <header><div class="container"><a href="index.html">← Zurück zur Startseite</a></div></header>
 
-<main class="container">
+<main class="container reveal">
   <h1>Datenschutzerklärung</h1>
 
   <h2>1. Verantwortliche Stelle</h2>
@@ -67,5 +68,6 @@
 </main>
 
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/impressum.html
+++ b/impressum.html
@@ -24,13 +24,14 @@
     .muted{opacity:.9}
     footer{margin-top:28px;opacity:.9;color:#123; padding:20px;border-top:1px solid var(--line); background:linear-gradient(180deg,var(--grad2),var(--grad1)); color:#eaf6ff; box-shadow:0 -6px 18px rgba(10,35,90,.25)}
   </style>
+  <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
 <header>
   <div class="container back"><a href="index.html">← Zurück zur Startseite</a></div>
 </header>
 
-<main class="container">
+<main class="container reveal">
   <h1>Impressum</h1>
 
   <p><strong>Siso-Team</strong><br>
@@ -60,5 +61,6 @@
 </main>
 
 <script>document.getElementById('y').textContent=new Date().getFullYear()</script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
       .cta:hover{transform:none}
     }
   </style>
+  <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
   <!-- Header -->
@@ -163,8 +164,8 @@
     <div class="container hero-grid">
       <div>
         <div class="kicker">ZUVERLÄSSIGE GEWERBLICHE REINIGUNG</div>
-        <h1>Ihr zuverlässiger Reinigungsservice</h1>
-        <p class="lead">Siso-Team ist ein zuverlässiges Reinigungsunternehmen. Wir arbeiten gründlich, flexibel und zu fairen Preisen – privat & gewerblich.</p>
+        <h1 class="fade-slide">Ihr zuverlässiger Reinigungsservice</h1>
+        <p class="lead fade-slide">Siso-Team ist ein zuverlässiges Reinigungsunternehmen. Wir arbeiten gründlich, flexibel und zu fairen Preisen – privat & gewerblich.</p>
         <p style="margin-top:18px">
           <a class="cta" href="https://wa.me/4915202052689?text=Hallo%20Siso%20Team,%20ich%20brauche%20ein%20Angebot." target="_blank" rel="noopener">Direkt per WhatsApp</a>
           &nbsp; <a class="cta" href="tel:+4915202052689">Anrufen</a>
@@ -178,7 +179,7 @@
 
   <!-- Über uns -->
   <section id="about">
-    <div class="container">
+    <div class="container reveal">
       <h2>Warum Siso-Team?</h2>
       <div class="workbox">
         <p><strong>Erfahrung & Qualität:</strong> Erfahrene Teams, hochwertige Reinigungsprodukte und strenge Hygienestandards – für sichtbar bessere Ergebnisse.</p>
@@ -189,7 +190,7 @@
 
   <!-- Arbeitsplätze (TEXT ONLY) -->
   <section id="arbeitsplaetze">
-    <div class="container">
+    <div class="container reveal">
       <h2>Wir arbeiten mit allen Arbeitsplatztypen</h2>
       <div class="workbox">
         <p>Wir betreuen private Haushalte und gewerbliche Kunden gleichermaßen – flexibel, diskret und zuverlässig. Typische Einsatzorte:</p>
@@ -207,7 +208,7 @@
   </section>
 
   <!-- Kontakte / Footer -->
-  <footer id="kontakte">
+  <footer id="kontakte" class="reveal">
     <div class="container footer-grid">
       <div>
         <h2>Kontakte</h2>
@@ -246,5 +247,6 @@
   // Jahr im Footer
   document.getElementById('y').textContent = new Date().getFullYear();
 </script>
+<script src="assets/script.js"></script>
 </body>
 </html>

--- a/referenzen.html
+++ b/referenzen.html
@@ -47,6 +47,7 @@
       .brand img{height:38px}
     }
   </style>
+  <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
 <header>
@@ -66,7 +67,7 @@
   </div>
 </header>
 
-<main class="container">
+<main class="container reveal">
   <h1>Referenzen</h1>
   <p class="sub">Fassaden-, Fenster- und Außenreinigung – eine Auswahl unserer Arbeiten.</p>
   <div class="grid">
@@ -126,5 +127,6 @@
   lbClose.addEventListener('click',()=>lb.classList.remove('open'));
   lb.addEventListener('click',e=>{ if(e.target===lb) lb.classList.remove('open'); });
 </script>
+<script src="assets/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fade/slide hero copy on load and reveal sections on scroll with IntersectionObserver
- Add smooth hover transitions with gentle scale/shadow for buttons and cards
- Respect `prefers-reduced-motion` across animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de80f08e8832cbdbd81a058ae1752